### PR TITLE
Refactor Dynamic Component to Page-based Navigation

### DIFF
--- a/src/components/drawers/BottomDrawer.svelte
+++ b/src/components/drawers/BottomDrawer.svelte
@@ -1,15 +1,32 @@
 <script lang="ts">
-	import { drawerData } from '../../data/drawerData';
+	import CreateExtIcon from '../icons/CreateExtIcon.svelte';
+	import DashboardIcon from '../icons/DashboardIcon.svelte';
+	import EditExtIcon from '../icons/EditExtIcon.svelte';
 
+  // The current active index of the item,
+  // this number is passed by the parent.
 	export let activeIndex: number;
-	export let handleDrawerChange: (i: number) => void;
 </script>
 
-<div class="btm-nav btm-nav-md shadow-xl md:hidden">
-	{#each drawerData as v (v.id)}
-		<button on:click={() => handleDrawerChange(v.id)} class={activeIndex === v.id ? 'active' : ''}>
-			<!-- DYNAMIC ICONs -->
-			<svelte:component this={drawerData[v.id].icon} />
+<div class="btm-nav btm-nav-md z-50 shadow-xl md:hidden">
+	<!-- DASHBOARD -->
+	<a href="/" class={activeIndex === 0 ? 'active' : ''}>
+		<button>
+			<DashboardIcon />
 		</button>
-	{/each}
+	</a>
+
+	<!-- CREATE -->
+	<a href="/create" class={activeIndex === 1 ? 'active' : ''}>
+		<button>
+			<CreateExtIcon />
+		</button>
+	</a>
+
+	<!-- EDIT -->
+	<a href="/edit" class={activeIndex === 2 ? 'active' : ''}>
+		<button>
+			<EditExtIcon />
+		</button>
+	</a>
 </div>

--- a/src/components/drawers/MainDrawer.svelte
+++ b/src/components/drawers/MainDrawer.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { drawerData } from '../../data/drawerData';
 
+	// The current active index of the item,
+	// this number is passed by the parent.
 	export let activeIndex: number;
-	export let handleDrawerChange: (i: number) => void;
 </script>
 
 <div class="drawer">
@@ -23,7 +24,7 @@
 					<label
 						for="left-drawer"
 						aria-label="Close Drawer"
-						class="drawer-button btn btn-outline btn-circle btn-sm"
+						class="btn-outline drawer-button btn-sm btn-circle btn"
 					>
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
@@ -52,10 +53,7 @@
 			<div class="py-8">
 				{#each drawerData as v (v.id)}
 					<li class="py-1">
-						<button
-							on:click={() => handleDrawerChange(v.id)}
-							class={activeIndex === v.id ? 'active' : ''}>{v.title}</button
-						>
+						<a href={v.href} class={activeIndex === v.id ? 'active' : ''}>{v.title}</a>
 					</li>
 				{/each}
 			</div>

--- a/src/data/drawerData.ts
+++ b/src/data/drawerData.ts
@@ -1,43 +1,23 @@
-import type { SvelteComponentTyped } from 'svelte';
-import IndexBody from '../components/body/IndexBody.svelte';
-import IndexHeader from '../components/header/IndexHeader.svelte';
-import CreateExtHeader from '../components/header/CreateExtHeader.svelte';
-import EditExtHeader from '../components/header/EditExtHeader.svelte';
-import CreateExtensionBody from '../components/body/CreateExtensionBody.svelte';
-import EditExtensionBody from '../components/body/EditExtensionBody.svelte';
-
-import DashboardIcon from '../components/icons/DashboardIcon.svelte';
-import CreateExtIcon from '../components/icons/CreateExtIcon.svelte';
-import EditExtIcon from '../components/icons/EditExtIcon.svelte';
-
 export interface IDrawerData {
 	id: number;
 	title: string;
-	header: new (...args: any) => SvelteComponentTyped;
-	component: new (...args: any) => SvelteComponentTyped;
-	icon: new (...args: any) => SvelteComponentTyped;
+	href: string;
 }
 
 export const drawerData: IDrawerData[] = [
 	{
 		id: 0,
 		title: 'Dashboard',
-		header: IndexHeader,
-		component: IndexBody,
-		icon: DashboardIcon
+		href: '/'
 	},
 	{
 		id: 1,
 		title: 'Create Extensions',
-		header: CreateExtHeader,
-		component: CreateExtensionBody,
-		icon: CreateExtIcon
+		href: '/create'
 	},
 	{
 		id: 2,
 		title: 'Edit Extensions',
-		header: EditExtHeader,
-		component: EditExtensionBody,
-		icon: EditExtIcon
+		href: '/edit'
 	}
 ];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,29 +1,25 @@
 <script lang="ts">
-	import { drawerData } from '../data/drawerData';
-	import MainDrawer from '../components/drawers/MainDrawer.svelte';
 	import BottomDrawer from '../components/drawers/BottomDrawer.svelte';
-
-	// the id of the active drawer
-	let activeDrawer = 0;
-
-	// handle drawer change when user click on different items.
-	function handleDrawerChange(i: number) {
-		activeDrawer = i;
-	}
+	import IndexHeader from '../components/header/IndexHeader.svelte';
+	import IndexBody from '../components/body/IndexBody.svelte';
+	import MainDrawer from '../components/drawers/MainDrawer.svelte';
 </script>
 
 <svelte:head>
 	<title>Binder</title>
 </svelte:head>
 
-<!-- DRAWER WRAPPER -->
-<MainDrawer activeIndex={activeDrawer} {handleDrawerChange}>
+<MainDrawer activeIndex={0}>
 	<!-- HEADER -->
-	<svelte:component this={drawerData[activeDrawer].header} />
+	<header>
+		<IndexHeader />
+	</header>
 
-	<!-- DYNAMIC COMPONENT BODY -->
-	<svelte:component this={drawerData[activeDrawer].component} />
+	<!-- BODY -->
+	<main>
+		<IndexBody />
+	</main>
 </MainDrawer>
 
 <!-- BOTTOM DRAWER (MOBILE ONLY) -->
-<BottomDrawer activeIndex={activeDrawer} {handleDrawerChange} />
+<BottomDrawer activeIndex={0} />

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import CreateExtensionBody from '../../components/body/CreateExtensionBody.svelte';
+	import CreateExtHeader from '../../components/header/CreateExtHeader.svelte';
+	import BottomDrawer from '../../components/drawers/BottomDrawer.svelte';
+	import MainDrawer from '../../components/drawers/MainDrawer.svelte';
+</script>
+
+<svelte:head>
+	<title>Create new extension | Binder</title>
+</svelte:head>
+
+<MainDrawer activeIndex={1}>
+	<!-- HEADER -->
+	<header>
+		<CreateExtHeader />
+	</header>
+
+	<!-- BODY -->
+	<main>
+		<CreateExtensionBody />
+	</main>
+</MainDrawer>
+
+<!-- BOTTOM DRAWER (MOBILE ONLY) -->
+<BottomDrawer activeIndex={1} />

--- a/src/routes/edit/+page.svelte
+++ b/src/routes/edit/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import BottomDrawer from '../../components/drawers/BottomDrawer.svelte';
+	import EditExtHeader from '../../components/header/EditExtHeader.svelte';
+	import EditExtensionBody from '../../components/body/EditExtensionBody.svelte';
+	import MainDrawer from '../../components/drawers/MainDrawer.svelte';
+</script>
+
+<svelte:head>
+	<title>Edit extension | Binder</title>
+</svelte:head>
+
+<MainDrawer activeIndex={2}>
+	<!-- HEADER -->
+	<header>
+		<EditExtHeader />
+	</header>
+
+	<!-- BODY -->
+	<main>
+		<EditExtensionBody />
+	</main>
+</MainDrawer>
+
+<!-- BOTTOM DRAWER (MOBILE ONLY) -->
+<BottomDrawer activeIndex={2} />


### PR DESCRIPTION
Refactor dynamic component navigation into the plain good old page based navigation. The reason behind the refactoring is the unreliable and too much waste of resource when using dynamic component, not to mention the inconsistency and bad user-experience, when the user try to reload when they create/edit the extension, the component will reverse back to dashboard component, since the state of the index perished and back to default number. 

When using page based navigation, each page responsible for their own job, either SSR the data or manage their state instead of crowdy do all the stuff in the index page and pass the data through props or whatever.